### PR TITLE
Build/android

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -94,6 +94,9 @@ jobs:
       - name: Gradle Assemble Debug
         run: cd android && ./gradlew assembleDebug
 
+      - name: Find APK
+        run: find . -name '*.apk'
+
       - name: Rename Debug APK
         run: |
           mv app/android/app/build/outputs/apk/debug/app-debug.apk app/android/app/build/outputs/apk/debug/LootLogger.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -105,7 +105,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: apk
-          path: ./android/app/build/outputs/apk/debug/LootLogger.apk
+          # Add app, as this is the default working directory, but not used by the action
+          path: ./app/android/app/build/outputs/apk/debug/LootLogger.apk
           if-no-files-found: error
 
       - if: ${{ inputs.tag != '' }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -99,15 +99,15 @@ jobs:
 
       - name: Rename Debug APK
         run: |
-          mv app/android/app/build/outputs/apk/debug/app-debug.apk app/android/app/build/outputs/apk/debug/LootLogger.apk
+          mv ./android/app/build/outputs/apk/debug/app-debug.apk ./android/app/build/outputs/apk/debug/LootLogger.apk
 
       - name: Upload APK as Artifact
         uses: actions/upload-artifact@v4
         with:
           name: apk
-          path: app/android/app/build/outputs/apk/debug/LootLogger.apk
+          path: ./android/app/build/outputs/apk/debug/LootLogger.apk
           if-no-files-found: error
 
       - if: ${{ inputs.tag != '' }}
         name: Upload APK to GitHub Release
-        run: gh release upload ${{ inputs.tag }} app/android/app/build/outputs/apk/debug/LootLogger.apk
+        run: gh release upload ${{ inputs.tag }} ./android/app/build/outputs/apk/debug/LootLogger.apk


### PR DESCRIPTION
This is a PITA, because there is a default `app/` working directory set for all `run` commands, but the actions (actions/upload-artifact@v4) dont respect the default 