### PR TITLE
fix: on successful login, set the current user in the realm context

### DIFF
--- a/app/src/context/RealmContext.tsx
+++ b/app/src/context/RealmContext.tsx
@@ -41,7 +41,11 @@ export const RealmProvider = ({ children }: { children: ReactNode }) => {
    
     async function login(email: string, password: string) {
         const credentials = Realm.Credentials.emailPassword(email, password);
-        return app.logIn(credentials)
+        const user = await app.logIn(credentials)
+        if (user !== null) {
+            setCurrentUser(user)
+        }
+        return user
     }
 
     async function register(email: string, password: string) {


### PR DESCRIPTION
this fixes auto login on first signup, where the realm user was not set after login